### PR TITLE
Fix 'DoctrineDataCollector::correct' set unserializable data

### DIFF
--- a/src/Sorien/DataCollector/DoctrineDataCollector.php
+++ b/src/Sorien/DataCollector/DoctrineDataCollector.php
@@ -123,6 +123,12 @@ class DoctrineDataCollector extends DataCollector
                 $query['explainable'] = false;
             }
         }
+        if ($query['sql'] instanceof \Doctrine\DBAL\Query\QueryBuilder) {
+            $queryBuilder = $query['sql'];
+            $sql = $queryBuilder->getSQL();
+            unset($query['sql']);
+            $query['sql'] = $sql;
+        }
 
         return $query;
     }


### PR DESCRIPTION
If you use QueryBuilder, failed to serialize query.

``` php
// Doctrine\DBAL\Logging\DebugStack
public function startQuery($sql, array $params = null, array $types = null)
// $sql is not string, but instance of QueryBuilder.
```

``` php
// Symfony\Component\HttpKernel\Profiler\Profiler
public function saveProfile(Profile $profile)
{
    ...
    if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
        $this->logger->warning('Unable to store the profiler information.');
    }
    ...
```

``` php
// Symfony\Component\HttpKernel\Profiler\FileProfilerStorage
public function write(Profile $profile)
{
    ...
    if (false === file_put_contents($file, serialize($data))) { // Fail to serialize, Exception occurs
```

To serialize instance of 'QueryBuilder' fail.
So ’$sql' should be set as string(=serializable).
