### PR TITLE
Add disabled class to menu label if no data is available

### DIFF
--- a/src/Sorien/Resources/views/Collector/db.html.twig
+++ b/src/Sorien/Resources/views/Collector/db.html.twig
@@ -31,7 +31,7 @@
 {% endblock %}
 
 {% block menu %}
-<span class="label">
+<span class="label {% if collector.querycount == 0 %}disabled{% endif %}">
     <span class="icon">
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
             <path fill="#AAAAAA" d="M5,8h14c1.7,0,3-1.3,3-3s-1.3-3-3-3H5C3.3,2,2,3.3,2,5S3.3,8,5,8z M18,3.6c0.8,0,1.5,0.7,1.5,1.5S18.8,6.6,18,6.6s-1.5-0.7-1.5-1.5S17.2,3.6,18,3.6z M19,9H5c-1.7,0-3,1.3-3,3s1.3,3,3,3h14c1.7,0,3-1.3,3-3S20.7,9,19,9z M18,13.6


### PR DESCRIPTION
Menu labels have the `disabled` class set, if no data is available for this service. This patch will make the look-and-feel consistent with the other providers of the Silex Web Profiler.